### PR TITLE
added varint encoder and serialize functions

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,3 @@
+SERIAL_RECORD_INT = 4 # Treat all ints as 4-byte (SQLite:Value is a big-endian 32-bit twos-complement integer)
+SERIAL_RECORD_NULL = 0
+SERIAL_RECORD_FLOAT = 7

--- a/src/record_serializer.py
+++ b/src/record_serializer.py
@@ -1,0 +1,109 @@
+# Function: This component is responsible for converting your structured Python data (e.g., a dictionary representing a row) into a compact, efficient byte string that can be stored on disk, and vice-versa. This is where you decide how different data types (integers, strings, booleans) are encoded.
+
+# Key Responsibilities:
+    # serialize(record: dict) -> bytes: Takes a Python dictionary (your "row") and turns it into a byte string. You'll need to decide on a format (e.g., length-prefixed strings, fixed-size integers).
+        # Use varints for header size, and serial types
+    # deserialize(data: bytes) -> dict: Takes a byte string from disk and reconstructs the Python dictionary.
+
+# Interaction: The RecordStore will use the RecordSerializer whenever it needs to write a record to disk or read one from disk.
+
+
+import constants
+import struct
+
+class RecordSerializer:
+
+    def __init__(self):
+        pass
+
+# I want to mimic record stores in SQLite meaning we have an integer --> type mapping that shows us which datatype a given bytestream should be in
+
+# Serial Type	Content Size	Meaning
+# 0	0	Value is a NULL.
+# 1	1	Value is an 8-bit twos-complement integer.
+# 2	2	Value is a big-endian 16-bit twos-complement integer.
+# 3	3	Value is a big-endian 24-bit twos-complement integer.
+# 4	4	Value is a big-endian 32-bit twos-complement integer.
+# 5	6	Value is a big-endian 48-bit twos-complement integer.
+# 6	8	Value is a big-endian 64-bit twos-complement integer.
+# 7	8	Value is a big-endian IEEE 754-2008 64-bit floating point number.
+# 8	0	Value is the integer 0. (Only available for schema format 4 and higher.)
+# 9	0	Value is the integer 1. (Only available for schema format 4 and higher.)
+# 10,11	variable	Reserved for internal use. These serial type codes will never appear in a well-formed database file, but they might be used in transient and temporary database files that SQLite sometimes generates for its own use. The meanings of these codes can shift from one release of SQLite to the next.
+# N≥12 and even	(N-12)/2	Value is a BLOB that is (N-12)/2 bytes in length.
+# N≥13 and odd	(N-13)/2	Value is a string in the text encoding and (N-13)/2 bytes in length. The nul terminator is not stored.
+
+
+ # In SQLitem, headers and serial record types are encoded into varints which I want to mimic
+
+    def encode_varint(n: int) -> bytes:
+    # The varint algorithm is to stores header_sizes and serial_records in as little space as possible. It transform any int value into multiple 7 bit chunks (usually just 1 is enough)
+    # We transform the given n into bits and then take chunks of 7 bits (we use the 1st bit to show if there are more 7-bit chunks to read or not)
+    # taking the number 300 for example: would be 1_0010_1100
+    # while the values are greater than 128 (8 bits) we are going to continue using multiple 7-bit chunks to stores them
+    # so we take the first 7 bits --> 010_1100, and append it to chunks_list list of 7 bit chunks, every 7-bit chunk gets a digit
+    # since there are more bits coming, we add a 1 to the front of the 7 bit --> 1010_1100, is the int=172 --> 0xac (we append this hex to our list)
+    # now we shift 7 bits to the left from from the original 1_0010_1100 we are now are here 1_0(here)010_1100 which is the same as 000_0010 as a 7 bit chunk
+    # now that the rest of the 7 bit chunks are just going to be 0s, we know we are done and don't have to add a 1 to the front of this 7 bit chunk, and we just have 0000_0010 which is int = 2 --> 0x02 (we append this hex to our list)
+
+        # can we fit the n into a single 7 bit chunk?
+        if n < 128:
+            # if yes then just return it as bytes
+            return bytes([n])
+        # otherwise lets start a list to append multiple 7 bit chunks
+        chunks_list = []
+        # while we need more than one 7 bit chunk to store the n
+        while n >= 128:
+            # continue appending the 7 bit chunks and adding 128 (which is the same as adding a 1 to a 7 bit chunk since 1000_0000 in bits is 128)
+            chunks_list.append((n & 127) | 128)
+            # and then move up 7 bits to the left to get the next 7 bits (same as adjusting n by the number of times its divisible by 128)
+            n = n//128
+        # we can then append this value (max 255--> 8 bits 1111_1111) to chunks list and process the next 7 bits
+        chunks_list.append(n)
+        return bytes(reversed(chunks_list))
+    
+    def decode_varint(encoded_varint:bytes) -> int:
+        pass
+
+
+    # Now that we have the function to encode an int into as few hexadecimals as possible we can start encoding and serializing a record into a bytestream
+    def serialize(record: dict) -> bytes:
+                    
+        header_fields = []
+        body = []
+
+        for value in record.values():
+            if value is None:
+                serial_type = constants.SERIAL_RECORD_NULL
+                body_bytes = b''
+
+            elif isinstance(value, int):
+                serial_type = constants.SERIAL_RECORD_INT
+                body_bytes = value.to_bytes(serial_type, 'big', signed=True)
+
+            elif isinstance(value, float):
+                serial_type = constants.SERIAL_RECORD_FLOAT
+                body_bytes = struct.pack('>d', value)
+
+            elif isinstance(value, str):
+                encoded = value.encode('utf-8')
+                serial_type = 13 + len(encoded) * 2  # odd => text
+                body_bytes = encoded
+            else:
+                raise TypeError(f"No support for type: {type(value)} yet")
+
+            header_fields.append(encode_varint(serial_type))         
+            body.append(body_bytes)
+
+        # Header size = size of all serial type varints + varint(header_size)
+        # take header fields and turn them from list to bytestream
+        header_bytestream = b''.join(header_fields)
+        # Get total header size to encode
+        header_size = len(header_bytestream) + 1 #here we are assuming that we won't have more than 128 columns so header_length is always 1 byte long
+
+        full_header = encode_varint(header_size) + header_bytestream
+
+        return full_header + b''.join(body)
+    
+    def deserialize(bytestream:bytes) -> dict:
+        pass

--- a/src/test_notebook.ipynb
+++ b/src/test_notebook.ipynb
@@ -1,5 +1,292 @@
 {
- "cells": [],
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 205,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "record = {\"name\":\"jon\",\"age\":30,\"married\":True,\"rating\":7.8}\n",
+    "schema = {\"name\":str,\"age\":int,\"married\":bool,\"rating\":float,\"income\":int}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 206,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'\\x05\\x13\\x04\\x04\\x07jon\\x00\\x00\\x00\\x1e\\x00\\x00\\x00\\x01@\\x1f333333'\n"
+     ]
+    }
+   ],
+   "source": [
+    "header_fields = []\n",
+    "body = []\n",
+    "\n",
+    "for value in record.values():\n",
+    "    if value is None:\n",
+    "        serial_type = constants.SERIAL_RECORD_NULL\n",
+    "        body_bytes = b''\n",
+    "\n",
+    "    elif isinstance(value, int):\n",
+    "        serial_type = constants.SERIAL_RECORD_INT\n",
+    "        body_bytes = value.to_bytes(serial_type, 'big', signed=True)\n",
+    "\n",
+    "    elif isinstance(value, float):\n",
+    "        serial_type = constants.SERIAL_RECORD_FLOAT\n",
+    "        body_bytes = struct.pack('>d', value)\n",
+    "\n",
+    "    elif isinstance(value, str):\n",
+    "        encoded = value.encode('utf-8')\n",
+    "        serial_type = 13 + len(encoded) * 2  # odd => text\n",
+    "        body_bytes = encoded\n",
+    "    else:\n",
+    "        raise TypeError(f\"No support for type: {type(value)} yet\")\n",
+    "    \n",
+    "\n",
+    "    header_fields.append(encode_varint(serial_type))         \n",
+    "    body.append(body_bytes)\n",
+    "\n",
+    "# Header size = size of all serial type varints + varint(header_size)\n",
+    "# take header fields and turn them from list to bytestream\n",
+    "header_bytestream = b''.join(header_fields)\n",
+    "# Get total header size to encode\n",
+    "header_size = len(header_bytestream) + 1 #here we are assuming that we won't have more than 128 columns so header_length is always 1 byte long\n",
+    "\n",
+    "full_header = encode_varint(header_size) + header_bytestream\n",
+    "\n",
+    "row = full_header + b''.join(body)\n",
+    "print(row)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 201,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'\\x05\\x13\\x04\\x04\\x07jon\\x00\\x00\\x00\\x1e\\x00\\x00\\x00\\x01@\\x1f333333'"
+      ]
+     },
+     "execution_count": 201,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "row"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 203,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "i = 0 \n",
+    "\n",
+    "# while i < len(row):\n",
+    "\n",
+    "header_size = row[0]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 204,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 204,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "header_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import struct\n",
+    "\n",
+    "# The varint algorithm is to stores header_sizes and serial_records in as little space as possible. It transform any int value into multiple 7 bit chunks (usually just 1 is enough)\n",
+    "# We transform the given n into bits and then take chunks of 7 bits (we use the 1st bit to show if there are more 7-bit chunks to read or not)\n",
+    "# taking the number 300 for example: would be 1_0010_1100\n",
+    "# while the values are greater than 128 (8 bits) we are going to continue using multiple 7-bit chunks to stores them\n",
+    "# so we take the first 7 bits --> 010_1100, and append it to chunks_list list of 7 bit chunks, every 7-bit chunk gets a digit\n",
+    "# since there are more bits coming, we add a 1 to the front of the 7 bit --> 1010_1100, is the int=172 --> 0xac (we append this hex to our list)\n",
+    "# now we shift 7 bits to the left from from the original 1_0010_1100 we are now are here 1_0(here)010_1100 which is the same as 000_0010 as a 7 bit chunk\n",
+    "# now that the rest of the 7 bit chunks are just going to be 0s, we know we are done and don't have to add a 1 to the front of this 7 bit chunk, and we just have 0000_0010 which is int = 2 --> 0x02 (we append this hex to our list)\n",
+    "\n",
+    "def encode_varint(n: int) -> bytes:\n",
+    "    # can we fit the n into a single 7 bit chunk?\n",
+    "    if n < 128:\n",
+    "        # if yes then just return it as bytes\n",
+    "        return bytes([n])\n",
+    "    # otherwise lets start a list to append multiple 7 bit chunks\n",
+    "    chunks_list = []\n",
+    "    # while we need more than one 7 bit chunk to store the n\n",
+    "    while n >= 128:\n",
+    "        # continue appending the 7 bit chunks and adding 128 (which is the same as adding a 1 to a 7 bit chunk since 1000_0000 in bits is 128)\n",
+    "        chunks_list.append((n & 127) | 128)\n",
+    "        # and then move up 7 bits to the left to get the next 7 bits (same as adjusting n by the number of times its divisible by 128)\n",
+    "        n = n//128\n",
+    "    # we can then append this value (max 255--> 8 bits 1111_1111) to chunks list and process the next 7 bits\n",
+    "    chunks_list.append(n)\n",
+    "    return bytes(reversed(chunks_list))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'\\x02\\xac'"
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "encode_varint(300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_list.append(127 | 128)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 3 \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_list.append((n & 127) | 128)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[131]"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_list\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "44"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "300 & 127"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0xac'"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hex(172)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
  "metadata": {
   "kernelspec": {
    "display_name": "simpledb_env",


### PR DESCRIPTION
# Pull Request Summary

## ✨ Changes to the Repo  

- started the record_serializer class which is meant to go between taking a python dictionary and turning it into a bytestream, and taking a bytestream and turning it into a python disctionary (this includes serialize/deserialize functions, and also encoding and decoding varints for headers which are meant to work as metadata for a given row

- Added the serialize function which serializes a python dictionary into a bytestream
- Added an encode_varint function which turns any int into a hexadecimal representation which consumers the lowest possible amount of memory --> this is so that we can confidently say that metadata takes up the lowest amount of memory (bytes) that it needs.


## ⚖️ Tradeoffs

- I decided to add SQLite type headers and serial_types to my rows as metadata because otherwise all my type and encoding would have to be done manually
- When it comes to header sizes, I have so far limited simpledb to only allow rows with columns up to 127


## ✅ Testing  

- no testing yet